### PR TITLE
docs: clarify C# Dev Kit vs classic extension + link fix steps

### DIFF
--- a/book-1-foundations/chapters/book-1-installations.md
+++ b/book-1-foundations/chapters/book-1-installations.md
@@ -14,6 +14,56 @@ When the download completes, run (open) the file downloaded by your browser and 
 Verify that the install has worked by opening a new terminal and running `dotnet --version`. You should see `8.0.101`, or something similar. If your terminal doesn't recognize the command, ask an instructor to help. 
 
 
-## C# Extension for VS Code
-The official C# extension from Microsoft for VS Code provides a number of helpful features including syntax highlighting, Intellisense (code completion and hints) and tools for debugging in your editor. <br>
-Install it by searching for `C#` in the extensions tab (open with Ctrl+Shift+X), select the C# extension by Microsoft and click `Install`.
+## C# Extension for VS Code <a id="c-extension-setup"></a>
+Microsoft now offers **two C# extensions** with overlapping names, which can cause confusion. Here’s how to choose the right one for bootcamp tutorials:
+
+---
+
+### **Option 1: Classic C# Extension (Recommended)**
+**Why**: Generates `.vscode` config files automatically, aligns with tutorials.  
+**How to Install**:
+
+```bash
+# Install the classic C# extension
+code --install-extension ms-dotnettools.csharp
+```
+
+⚠️ **Marketplace Warning**:  
+The marketplace description says "*We highly recommend using C# Dev Kit*" – **ignore this** for bootcamp work. The "classic" extension (ID: `ms-dotnettools.csharp`) is the one you want.
+
+---
+
+### **Option 2: C# Dev Kit (Not Recommended for Bootcamp)**  
+**Why Avoid**:  
+- Hides `.vscode` folder (configs are internal)  
+- Changes debugging workflows (uses "Projects" tab instead of `launch.json`)  
+- Often auto-installs itself if you follow Microsoft’s prompts  
+
+
+
+## Manual Debug Setup
+If you accidentally installed it:  
+```bash
+# Full cleanup (Dev Kit + dependencies)
+code --uninstall-extension ms-dotnettools.csdevkit
+code --uninstall-extension ms-dotnettools.vscode-dotnet-runtime
+```
+
+---
+
+### **Post-Install Setup**  
+After installing the classic extension:  
+1. Open your C# project in VS Code  
+2. Press `Ctrl+Shift+P` → Run **`.NET: Generate Assets for Build and Debug`**  
+3. A `.vscode` folder will appear with `launch.json`/`tasks.json`  
+
+🔍 **Verify Your Setup**:  
+```bash
+# Should show ONLY 'ms-dotnettools.csharp'
+code --list-extensions | grep dotnettools
+```
+
+---
+
+### **Why This Matters**  
+Corporate tooling (C# Dev Kit) prioritizes "simplicity" over transparency. By reverting to the classic extension, you regain control over debugging configurations – critical for learning how .NET projects actually work under the hood.

--- a/book-1-foundations/chapters/setting-up-console-app.md
+++ b/book-1-foundations/chapters/setting-up-console-app.md
@@ -12,6 +12,7 @@ It's time to make your first program! When you installed the .NET SDK (Software 
 1. run `dotnet new gitignore`
 1. Open the project in VS Code with `code .`
 1. When the project opens in VS Code, you will see a dialog that looks like this. Click Yes.<br> ![debug-assets](../../assets/build-and-debug-assets.png)<br> If you don't see this dialog, you can generate these assets manually typing `ctrl-shift-P >` and typing `.NET: Generate Assets For Build and Debug` in the input field
+    >⚠️ _**Don’t see it?**_ ➔ [Why this happens & how to fix](book-1-installations.md#c-extension-for-vs-code)
 1. When you are done, your folder structure should look like this: <br>
 ![console-file-structure](../../assets/console-file-structure.png)<br>
 1. Open `launch.json` in the `.vscode` folder. Change `"console": "internalConsole"` to `"console": "integratedTerminal"`, and save the file. 

--- a/book-2-web-apis/chapters/web-api-setup.md
+++ b/book-2-web-apis/chapters/web-api-setup.md
@@ -37,7 +37,7 @@ Type `Ctrl+C` in the terminal to shut the API down now.
 6. You should see this dialog from VS Code (click Yes):
 ![build and debug assets confirmation](../../assets/honey-raes-assets-confirm.png)
 If you don't see this dialog, you can generate these assets manually typing `ctrl-shift-P >` and typing `.NET: Generate Assets For Build and Debug` in the input field
-
+    >⚠️ _**Don’t see it?**_ ➔ [Why the dialog doesn’t appear](../../book-1-foundations/chapters/book-1-installations.md#c-extension-for-vs-code)
 ## A tour of the scaffolded project
 
 ### What's the same


### PR DESCRIPTION
##  **Title**:  
 **docs: clarify C# Dev Kit vs classic extension and restore `.vscode` config flow**

---

**Description**:

### Problem

Recent versions of VS Code now prioritize the **C# Dev Kit** extension, which changes expected behavior around debugging. Specifically:

- `.vscode/launch.json` and `tasks.json` are **not generated**
- Students **don’t see the “generate assets” prompt**
- Debugging workflows assumed in tutorials **fail silently**
- The Marketplace **encourages Dev Kit**, which installs dependencies automatically — making the setup look correct when it’s not

### Root Cause

- **C# Dev Kit** (`ms-dotnettools.csdevkit`) is Microsoft's newer LSP-based toolchain
- It replaces the classic `ms-dotnettools.csharp` + OmniSharp workflow
- The Dev Kit **hides config files**, favoring a GUI-based `Projects` tab
- **Bootcamp instructions rely on explicit `.vscode` configs** for debugging

### Solution in this PR

- ✅ Adds clarification on **which extension to use**
- ✅ Provides CLI commands to uninstall Dev Kit and reinstall the classic C# extension
- ✅ Adds **internal links** to a new troubleshooting section
- ✅ Explains why the dialog might not appear and how to force-generate configs


---

### Supporting Evidence

- [Microsoft Docs — C# Dev Kit Overview](https://code.visualstudio.com/docs/csharp/get-started)
- [Stack Overflow — C# config not generating `launch.json` / `tasks.json`](https://stackoverflow.com/questions/75572318/problem-on-configuring-vscode-for-c-it-doesnt-generate-launch-json-and-tasks)

---

### 🔄 Impact

-  Students get consistent, reliable debugging behavior
- Troubleshooting workflow is documented and linkable
- Documentation now matches the real-world behavior of the tools

---